### PR TITLE
Improve admin financial and payments cohesion and responsive UI

### DIFF
--- a/app/static/css/admin.css
+++ b/app/static/css/admin.css
@@ -747,6 +747,77 @@ textarea.admin-form-control:-webkit-autofill {
     color: var(--admin-primary);
 }
 
+.admin-alert-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 1rem;
+    flex-shrink: 0;
+}
+
+.admin-alert-icon.success {
+    background: rgba(0, 255, 0, 0.2);
+    color: var(--admin-success);
+}
+
+.admin-alert-icon.info {
+    background: rgba(0, 255, 255, 0.2);
+    color: var(--admin-primary);
+}
+
+.admin-alert-icon.warning {
+    background: rgba(255, 165, 0, 0.2);
+    color: #ffa500;
+}
+
+.admin-page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.admin-page-header-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.admin-inline-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.admin-inline-stat {
+    background: var(--admin-bg-tertiary);
+    border: 1px solid var(--admin-border);
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    box-shadow: var(--admin-shadow);
+}
+
+.admin-inline-stat strong {
+    display: block;
+    font-size: 1.05rem;
+    color: var(--admin-text-primary);
+}
+
+.admin-inline-stat small {
+    color: var(--admin-text-muted);
+}
+
+.admin-stat-card .admin-btn {
+    width: 100%;
+    justify-content: center;
+}
+
 /* Admin Quick Actions */
 .admin-quick-actions {
     display: grid;
@@ -929,6 +1000,15 @@ textarea.admin-form-control:-webkit-autofill {
     
     .admin-stats-grid {
         grid-template-columns: 1fr;
+    }
+
+    .admin-page-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .admin-page-header-actions {
+        width: 100%;
     }
     
     .admin-quick-actions {

--- a/app/templates/admin/financial.html
+++ b/app/templates/admin/financial.html
@@ -5,12 +5,12 @@
 {% block breadcrumb %}<span class="breadcrumb-separator">/</span> <span>Financial Management</span>{% endblock %}
 
 {% block admin_content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="admin-page-header mb-4">
     <div>
         <h2 class="mb-1">Financial Management</h2>
         <p class="text-muted mb-0">Manage financial periods and track club finances</p>
     </div>
-    <div>
+    <div class="admin-page-header-actions">
         <a href="{{ url_for('admin.create_financial_period') }}" class="admin-btn admin-btn-primary">
             <i class="fas fa-plus"></i> New Financial Period
         </a>
@@ -44,6 +44,51 @@
         <div class="admin-stat-card {% if all_time_balance >= 0 %}success{% else %}danger{% endif %}">
             <h5>Tsh {{ "%.2f"|format(all_time_balance) }}</h5>
             <p>Net Balance</p>
+        </div>
+    </div>
+</div>
+
+<div class="admin-card mb-4">
+    <div class="admin-card-body">
+        <div class="admin-page-header">
+            <div>
+                <h5 class="mb-1">Membership Payments</h5>
+                <p class="text-muted mb-0">Payments feed into your budgets and revenue tracking.</p>
+            </div>
+            <div class="admin-page-header-actions">
+                <a href="{{ url_for('admin.payments') }}" class="admin-btn admin-btn-success">
+                    <i class="fas fa-dollar-sign"></i> View Payments
+                </a>
+            </div>
+        </div>
+        <div class="admin-inline-stats">
+            <div class="admin-inline-stat">
+                <strong>{{ membership_payments_count }}</strong>
+                <small>Total Payments</small>
+            </div>
+            <div class="admin-inline-stat">
+                <strong>Tsh {{ "%.2f"|format(membership_payments_total) }}</strong>
+                <small>Membership Revenue</small>
+            </div>
+            <div class="admin-inline-stat">
+                <strong>
+                    {% if current_period %}
+                    Tsh {{ "%.2f"|format(current_period_payments_total) }}
+                    {% else %}
+                    --
+                    {% endif %}
+                </strong>
+                <small>Current Period Payments</small>
+            </div>
+            <div class="admin-inline-stat">
+                <strong>{{ unassigned_payments_count }}</strong>
+                <small>Unassigned Payments</small>
+                {% if unassigned_payments_count %}
+                <div class="mt-1">
+                    <span class="admin-badge admin-badge-warning">Needs review</span>
+                </div>
+                {% endif %}
+            </div>
         </div>
     </div>
 </div>
@@ -231,7 +276,7 @@
 
 .admin-period-header {
     display: flex;
-    justify-content: between;
+    justify-content: space-between;
     align-items: center;
     margin-bottom: 0.5rem;
 }
@@ -275,24 +320,5 @@
     flex-wrap: wrap;
 }
 
-.admin-alert-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-right: 1rem;
-}
-
-.admin-alert-icon.success {
-    background: rgba(0, 255, 0, 0.2);
-    color: #00ff00;
-}
-
-.admin-alert-icon.warning {
-    background: rgba(255, 165, 0, 0.2);
-    color: #ffa500;
-}
 </style>
 {% endblock %}

--- a/app/templates/admin/payments.html
+++ b/app/templates/admin/payments.html
@@ -5,12 +5,15 @@
 {% block breadcrumb %}<span class="breadcrumb-separator">/</span> <span>Payments</span>{% endblock %}
 
 {% block admin_content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="admin-page-header mb-4">
     <div>
         <h2 class="mb-1">Membership Payments</h2>
         <p class="text-muted mb-0">Track all membership fee payments</p>
     </div>
-    <div>
+    <div class="admin-page-header-actions">
+        <a href="{{ url_for('admin.financial') }}" class="admin-btn admin-btn-outline">
+            <i class="fas fa-chart-line"></i> Financial Management
+        </a>
         <a href="{{ url_for('admin.export_payments', status=current_status, member_id=current_member_id) }}" 
            class="admin-btn admin-btn-success">
             <i class="fas fa-download"></i> Export to CSV
@@ -42,6 +45,27 @@
         </div>
     </div>
 </div>
+{% else %}
+<div class="admin-card mb-4">
+    <div class="admin-card-body">
+        <div class="d-flex align-items-center">
+            <div class="admin-alert-icon warning">
+                <i class="fas fa-exclamation-triangle"></i>
+            </div>
+            <div class="flex-grow-1">
+                <h5 class="mb-1">No Active Financial Period</h5>
+                <p class="mb-0 text-muted">
+                    Create a financial period so new payments are tied to a budget cycle.
+                </p>
+            </div>
+            <div>
+                <a href="{{ url_for('admin.create_financial_period') }}" class="admin-btn admin-btn-primary">
+                    <i class="fas fa-plus"></i> Create Period
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
 {% endif %}
 
 <!-- Statistics -->
@@ -65,10 +89,9 @@
         </div>
     </div>
     <div class="col-md-3">
-        <div class="admin-stat-card">
-            <a href="{{ url_for('admin.financial') }}" class="admin-btn admin-btn-outline admin-btn-sm">
-                <i class="fas fa-chart-line"></i> Financial Management
-            </a>
+        <div class="admin-stat-card warning">
+            <h5>{{ unassigned_payments_count }}</h5>
+            <p>Unassigned Payments</p>
         </div>
     </div>
 </div>
@@ -121,6 +144,7 @@
             <thead>
                 <tr>
                     <th>Member</th>
+                    <th>Period</th>
                     <th>Amount</th>
                     <th>Payment Date</th>
                     <th>Membership Period</th>
@@ -137,6 +161,15 @@
                             {{ payment.member.full_name }}
                         </a><br>
                         <small class="text-muted">{{ payment.member.member_id_number }}</small>
+                    </td>
+                    <td>
+                        {% if payment.financial_period %}
+                        <a href="{{ url_for('admin.financial_period_detail', period_id=payment.financial_period.id) }}">
+                            {{ payment.financial_period.name }}
+                        </a>
+                        {% else %}
+                        <span class="admin-badge admin-badge-warning">Unassigned</span>
+                        {% endif %}
                     </td>
                     <td><strong>Tsh {{ "%.2f"|format(payment.amount) }}</strong></td>
                     <td>{{ payment.payment_date.strftime('%Y-%m-%d') }}</td>
@@ -181,23 +214,3 @@
 </div>
 {% endif %}
 {% endblock %}
-
-{% block extra_head %}
-<style>
-.admin-alert-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-right: 1rem;
-}
-
-.admin-alert-icon.info {
-    background: rgba(0, 255, 255, 0.2);
-    color: #00ffff;
-}
-</style>
-{% endblock %}
-


### PR DESCRIPTION
### Motivation
- Payments and financial management were presented separately with little connection, causing unassigned payments and unclear budgeting context. The UI also had inconsistent header/layout styles that looked awkward on mobile and desktop. 
- The intent is to surface membership payment metrics inside the financial view, show when payments are not tied to a financial period, and make the admin pages visually consistent and responsive.

### Description
- Link membership payments into the financial overview by adding `membership_payments_total`, `membership_payments_count`, `unassigned_payments_count`, and `current_period_payments_total` to the `financial` route and template rendering in `app/routes/admin.py` and `app/templates/admin/financial.html`.
- Surface payment context and unassigned-payment warnings on the payments page by adding `unassigned_payments_count` to the `payments` route and showing the payment's `financial_period` (or an `Unassigned` badge) in `app/templates/admin/payments.html`.
- Improve admin layout and responsive behaviour by adding shared UI utilities and styles: `admin-alert-icon`, `admin-page-header`, `admin-page-header-actions`, and `admin-inline-stats` in `app/static/css/admin.css` and using them in the updated templates to unify headers, inline stats, and mobile stacking.
- Minor markup fixes in `app/templates/admin/financial.html` and `app/templates/admin/payments.html` for spacing, table column addition (`Period`), and `justify-content: space-between` corrections.

### Testing
- Performed repository inspection and template/route searches to locate affected code paths (grep/rg), and confirmed the template/route changes were wired together; these are static checks and succeeded.
- Attempted a minimal runtime check with a short Python snippet to import Flask (`python` check) which failed with "No module named 'flask'", so the application could not be started for live UI verification.
- No automated unit or integration tests were executed due to missing runtime dependencies in the environment (Flask not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848fa0d18c832b88865dc301b80a7f)